### PR TITLE
fix Disposeの書き方間違っていたのを修正

### DIFF
--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentralManager.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentralManager.cs
@@ -46,8 +46,6 @@ namespace CoreBluetooth
 
         CBCentralManager() { }
 
-        ~CBCentralManager() => Dispose(false);
-
         public static CBCentralManager Create(ICBCentralManagerDelegate centralDelegate = null)
         {
             var instance = new CBCentralManager();
@@ -235,18 +233,9 @@ namespace CoreBluetooth
 
         public void Dispose()
         {
-            Dispose(true);
-            System.GC.SuppressFinalize(this);
-        }
-
-        void Dispose(bool disposing)
-        {
             if (_disposed) return;
 
-            if (_handle != null && !_handle.IsInvalid)
-            {
-                _handle.Dispose();
-            }
+            _handle?.Dispose();
 
             _disposed = true;
         }


### PR DESCRIPTION
## disposingの削除

```
void Dispose(bool disposing)
```

の書き方はアンマネージドリソースを安全に解放するための書き方。

参考
https://qiita.com/hkuno/items/e35c7e306e852ced375d

その上で、handleはアンマネージドではなく、マネージドなためdisposingおよびデストラクタは不要(それらはSafeHandle側に書いてある)

## nullおよび、IsInvalidの確認について

Disposeメソッドはエラーを出すべきではない。
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1065#dispose-methods

また、SafeHandle.DisposeのドキュメントではIsInvalidの確認が必要とは書かれていない。 https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.safehandle.dispose?view=net-7.0#system-runtime-interopservices-safehandle-dispose

仮にIsInvalidな状態でDisposeを呼んでもエラーはでないはずなためIsInvalidの確認は外す。 nullチェックに関しては、このメソッドのみで「エラーが出る可能性がない状態」を担保できるようにするためにつけたほうが良いと判断。