### PR TITLE
rename DelegateMethodName

### DIFF
--- a/Assets/CoreBluetooth/Samples/01_Central/Sample_Central.cs
+++ b/Assets/CoreBluetooth/Samples/01_Central/Sample_Central.cs
@@ -20,69 +20,69 @@ namespace CoreBluetoothSample
             centralManager = CBCentralManager.Create(this);
         }
 
-        public void DiscoveredPeripheral(CBCentralManager central, CBPeripheral peripheral, int rssi)
+        public void DidDiscoverPeripheral(CBCentralManager central, CBPeripheral peripheral, int rssi)
         {
-            Debug.Log($"[DiscoveredPeripheral] peripheral: {peripheral}  rssi: {rssi}");
+            Debug.Log($"[DidDiscoverPeripheral] peripheral: {peripheral}  rssi: {rssi}");
             this.peripheral = peripheral;
             peripheral.Delegate = this;
             central.StopScan();
             central.Connect(peripheral);
         }
 
-        public void UpdatedState(CBCentralManager central)
+        public void DidUpdateState(CBCentralManager central)
         {
-            Debug.Log($"[UpdatedState] {central.State}");
+            Debug.Log($"[DidUpdateState] {central.State}");
             if (central.State == CBManagerState.PoweredOn)
             {
-                Debug.Log($"[UpdatedState] Start scanning for peripherals...");
+                Debug.Log($"[DidUpdateState] Start scanning for peripherals...");
                 central.ScanForPeripherals(new string[] { serviceUUID });
             }
         }
 
-        public void ConnectedPeripheral(CBCentralManager central, CBPeripheral peripheral)
+        public void DidConnectPeripheral(CBCentralManager central, CBPeripheral peripheral)
         {
-            Debug.Log($"[ConnectedPeripheral] peripheral: {peripheral}");
+            Debug.Log($"[DidConnectPeripheral] peripheral: {peripheral}");
             peripheral.DiscoverServices(new string[] { serviceUUID });
         }
 
-        public void DisconnectedPeripheral(CBCentralManager central, CBPeripheral peripheral, CBError error)
+        public void DidDisconnectPeripheral(CBCentralManager central, CBPeripheral peripheral, CBError error)
         {
-            Debug.Log($"[DisconnectedPeripheral] peripheral: {peripheral}  error: {error}");
+            Debug.Log($"[DidDisconnectPeripheral] peripheral: {peripheral}  error: {error}");
         }
 
-        public void FailedToConnect(CBCentralManager central, CBPeripheral peripheral, CBError error)
+        public void DidFailToConnectPeripheral(CBCentralManager central, CBPeripheral peripheral, CBError error)
         {
-            Debug.Log($"[FailedToConnect] peripheral: {peripheral}  error: {error}");
+            Debug.Log($"[DidFailToConnectPeripheral] peripheral: {peripheral}  error: {error}");
         }
 
-        public void DiscoveredService(CBPeripheral peripheral, CBError error)
+        public void DidDiscoverServices(CBPeripheral peripheral, CBError error)
         {
-            Debug.Log($"[DiscoveredService] peripheral: {peripheral}");
+            Debug.Log($"[DidDiscoverServices] peripheral: {peripheral}");
             if (error != null)
             {
-                Debug.LogError($"[DiscoveredService] error: {error}");
+                Debug.LogError($"[DidDiscoverServices] error: {error}");
                 return;
             }
 
             foreach (var service in peripheral.Services)
             {
-                Debug.Log($"[DiscoveredService] service: {service}, start discovering characteristics...");
+                Debug.Log($"[DidDiscoverServices] service: {service}, start discovering characteristics...");
                 peripheral.DiscoverCharacteristics(new string[] { characteristicUUID }, service);
             }
         }
 
-        public void DiscoveredCharacteristic(CBPeripheral peripheral, CBService service, CBError error)
+        public void DidDiscoverCharacteristics(CBPeripheral peripheral, CBService service, CBError error)
         {
-            Debug.Log($"[DiscoveredCharacteristic] peripheral: {peripheral}  service: {service}");
+            Debug.Log($"[DidDiscoverCharacteristics] peripheral: {peripheral}  service: {service}");
             if (error != null)
             {
-                Debug.LogError($"[DiscoveredCharacteristic] error: {error}");
+                Debug.LogError($"[DidDiscoverCharacteristics] error: {error}");
                 return;
             }
 
             foreach (var characteristic in service.Characteristics)
             {
-                Debug.Log($"[DiscoveredCharacteristic] characteristic: {characteristic}");
+                Debug.Log($"[DidDiscoverCharacteristics] characteristic: {characteristic}");
 
                 if (characteristic.UUID == characteristicUUID)
                 {
@@ -101,12 +101,12 @@ namespace CoreBluetoothSample
             }
         }
 
-        public void UpdatedCharacteristicValue(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error)
+        public void DidUpdateValueForCharacteristic(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error)
         {
-            Debug.Log($"[UpdatedCharacteristicValue] characteristic: {characteristic}");
+            Debug.Log($"[DidUpdateValueForCharacteristic] characteristic: {characteristic}");
             if (error != null)
             {
-                Debug.LogError($"[UpdatedCharacteristicValue] error: {error}");
+                Debug.LogError($"[DidUpdateValueForCharacteristic] error: {error}");
                 return;
             }
 
@@ -114,22 +114,22 @@ namespace CoreBluetoothSample
             Debug.Log($"Data: {str}");
         }
 
-        public void WroteCharacteristicValue(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error)
+        public void DidWriteValueForCharacteristic(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error)
         {
-            Debug.Log($"[WroteCharacteristicValue] characteristic: {characteristic}");
+            Debug.Log($"[DidWriteValueForCharacteristic] characteristic: {characteristic}");
             if (error != null)
             {
-                Debug.LogError($"[WroteCharacteristicValue] error: {error}");
+                Debug.LogError($"[DidWriteValueForCharacteristic] error: {error}");
                 return;
             }
         }
 
-        public void UpdatedNotificationState(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error)
+        public void DidUpdateNotificationStateForCharacteristic(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error)
         {
-            Debug.Log($"[UpdatedNotificationState] characteristic: {characteristic}");
+            Debug.Log($"[DidUpdateNotificationStateForCharacteristic] characteristic: {characteristic}");
             if (error != null)
             {
-                Debug.LogError($"[UpdatedNotificationState] error: {error}");
+                Debug.LogError($"[DidUpdateNotificationStateForCharacteristic] error: {error}");
                 return;
             }
         }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentralManager.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentralManager.cs
@@ -10,11 +10,11 @@ namespace CoreBluetooth
     /// </summary>
     public interface ICBCentralManagerDelegate
     {
-        void ConnectedPeripheral(CBCentralManager central, CBPeripheral peripheral) { }
-        void DisconnectedPeripheral(CBCentralManager central, CBPeripheral peripheral, CBError error) { }
-        void FailedToConnect(CBCentralManager central, CBPeripheral peripheral, CBError error) { }
-        void DiscoveredPeripheral(CBCentralManager central, CBPeripheral peripheral, int rssi) { }
-        void UpdatedState(CBCentralManager central);
+        void DidConnectPeripheral(CBCentralManager central, CBPeripheral peripheral) { }
+        void DidDisconnectPeripheral(CBCentralManager central, CBPeripheral peripheral, CBError error) { }
+        void DidFailToConnectPeripheral(CBCentralManager central, CBPeripheral peripheral, CBError error) { }
+        void DidDiscoverPeripheral(CBCentralManager central, CBPeripheral peripheral, int rssi) { }
+        void DidUpdateState(CBCentralManager central);
     }
 
     /// <summary>
@@ -125,7 +125,7 @@ namespace CoreBluetooth
             if (_disposed) return;
             var peripheral = GetPeripheral(peripheralId);
             if (peripheral == null) return;
-            Delegate?.ConnectedPeripheral(this, peripheral);
+            Delegate?.DidConnectPeripheral(this, peripheral);
         }
 
         internal void DidDisconnectPeripheral(string peripheralId, CBError error)
@@ -133,7 +133,7 @@ namespace CoreBluetooth
             if (_disposed) return;
             var peripheral = GetPeripheral(peripheralId);
             if (peripheral == null) return;
-            Delegate?.DisconnectedPeripheral(this, peripheral, error);
+            Delegate?.DidDisconnectPeripheral(this, peripheral, error);
         }
 
         internal void DidFailToConnect(string peripheralId, CBError error)
@@ -141,7 +141,7 @@ namespace CoreBluetooth
             if (_disposed) return;
             var peripheral = GetPeripheral(peripheralId);
             if (peripheral == null) return;
-            Delegate?.FailedToConnect(this, peripheral, error);
+            Delegate?.DidFailToConnectPeripheral(this, peripheral, error);
         }
 
         internal void DidDiscoverPeripheral(string peripheralId, string peripheralName, int rssi)
@@ -154,14 +154,14 @@ namespace CoreBluetooth
                 peripheral = new CBPeripheral(peripheralId, peripheralName, nativePeriphalProxy);
                 _peripherals.Add(peripheralId, peripheral);
             }
-            Delegate?.DiscoveredPeripheral(this, peripheral, rssi);
+            Delegate?.DidDiscoverPeripheral(this, peripheral, rssi);
         }
 
         internal void DidUpdateState(CBManagerState state)
         {
             if (_disposed) return;
             this.State = state;
-            Delegate?.UpdatedState(this);
+            Delegate?.DidUpdateState(this);
         }
 
         internal void PeripheralDidDiscoverServices(string peripheralId, string[] serviceUUIDs, CBError error)

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBPeripheral.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBPeripheral.cs
@@ -24,11 +24,11 @@ namespace CoreBluetooth
 
     public interface ICBPeripheralDelegate
     {
-        void DiscoveredService(CBPeripheral peripheral, CBError error) { }
-        void DiscoveredCharacteristic(CBPeripheral peripheral, CBService service, CBError error) { }
-        void UpdatedCharacteristicValue(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error) { }
-        void WroteCharacteristicValue(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error) { }
-        void UpdatedNotificationState(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error) { }
+        void DidDiscoverServices(CBPeripheral peripheral, CBError error) { }
+        void DidDiscoverCharacteristics(CBPeripheral peripheral, CBService service, CBError error) { }
+        void DidUpdateValueForCharacteristic(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error) { }
+        void DidWriteValueForCharacteristic(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error) { }
+        void DidUpdateNotificationStateForCharacteristic(CBPeripheral peripheral, CBCharacteristic characteristic, CBError error) { }
     }
 
     /// <summary>
@@ -110,30 +110,30 @@ namespace CoreBluetooth
         {
             _services.Clear();
             _services.AddRange(services);
-            Delegate?.DiscoveredService(this, error);
+            Delegate?.DidDiscoverServices(this, error);
         }
 
         internal void DidDiscoverCharacteristics(CBCharacteristic[] characteristics, CBService service, CBError error)
         {
             service.UpdateCharacteristics(characteristics);
-            Delegate?.DiscoveredCharacteristic(this, service, error);
+            Delegate?.DidDiscoverCharacteristics(this, service, error);
         }
 
         internal void DidUpdateValueForCharacteristic(CBCharacteristic characteristic, byte[] data, CBError error)
         {
             characteristic.UpdateValue(data);
-            Delegate?.UpdatedCharacteristicValue(this, characteristic, error);
+            Delegate?.DidUpdateValueForCharacteristic(this, characteristic, error);
         }
 
         internal void DidWriteValueForCharacteristic(CBCharacteristic characteristic, CBError error)
         {
-            Delegate?.WroteCharacteristicValue(this, characteristic, error);
+            Delegate?.DidWriteValueForCharacteristic(this, characteristic, error);
         }
 
         internal void DidUpdateNotificationStateForCharacteristic(CBCharacteristic characteristic, bool isNotifying, CBError error)
         {
             characteristic.UpdateIsNotifying(isNotifying);
-            Delegate?.UpdatedNotificationState(this, characteristic, error);
+            Delegate?.DidUpdateNotificationStateForCharacteristic(this, characteristic, error);
         }
 
         public override string ToString()

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCentralManagerTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCentralManagerTests.cs
@@ -11,7 +11,7 @@ namespace CoreBluetoothTests
     {
         public CBManagerState state { get; private set; } = CBManagerState.Unknown;
 
-        public void UpdatedState(CBCentralManager central) => state = central.State;
+        public void DidUpdateState(CBCentralManager central) => state = central.State;
     }
 
     public class CBCentralManagerTests


### PR DESCRIPTION
https://github.com/teach310/CoreBluetoothForUnity/issues/7#issuecomment-1738435200

Xamarinと同じ名前からswiftよりに戻す。

PeripheralManagerDelegateのメソッド名に統一感がなく、これを真似るのは避けたほうが良いと判断。 https://learn.microsoft.com/en-us/dotnet/api/corebluetooth.cbperipheralmanagerdelegate.stateupdated?view=xamarin-ios-sdk-12

ついでに DidConnect, DidDisconnectPeripheral のように Peripheralが付いたりつかなかったりするのが気になるため、付けるに統一