### PR TITLE
change CentralManager.Create to new

### DIFF
--- a/Assets/CoreBluetooth/Samples/01_Central/Sample_Central.cs
+++ b/Assets/CoreBluetooth/Samples/01_Central/Sample_Central.cs
@@ -17,7 +17,7 @@ namespace CoreBluetoothSample
 
         void Start()
         {
-            centralManager = CBCentralManager.Create(this);
+            centralManager = new CBCentralManager(this);
         }
 
         public void DidDiscoverPeripheral(CBCentralManager central, CBPeripheral peripheral, int rssi)

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentralManager.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentralManager.cs
@@ -44,15 +44,11 @@ namespace CoreBluetooth
 
         NativeCentralManagerProxy _nativeCentralManagerProxy;
 
-        CBCentralManager() { }
-
-        public static CBCentralManager Create(ICBCentralManagerDelegate centralDelegate = null)
+        public CBCentralManager(ICBCentralManagerDelegate centralDelegate = null)
         {
-            var instance = new CBCentralManager();
-            instance._handle = SafeNativeCentralManagerHandle.Create(instance);
-            instance.Delegate = centralDelegate;
-            instance._nativeCentralManagerProxy = new NativeCentralManagerProxy(instance._handle);
-            return instance;
+            _handle = SafeNativeCentralManagerHandle.Create(this);
+            Delegate = centralDelegate;
+            _nativeCentralManagerProxy = new NativeCentralManagerProxy(_handle);
         }
 
         void ThrowIfPeripheralNotDiscovered(CBPeripheral peripheral)

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeCentralManagerHandle.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeCentralManagerHandle.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace CoreBluetooth
 {
-    public class SafeNativeCentralManagerHandle : SafeHandle
+    internal class SafeNativeCentralManagerHandle : SafeHandle
     {
         static Dictionary<IntPtr, CBCentralManager> s_centralManagerMap = new Dictionary<IntPtr, CBCentralManager>();
 

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCentralManagerTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCentralManagerTests.cs
@@ -9,9 +9,9 @@ namespace CoreBluetoothTests
 {
     public class CBCentralManagerDelegateMock : ICBCentralManagerDelegate
     {
-        public CBManagerState state { get; private set; } = CBManagerState.Unknown;
+        public CBManagerState State { get; private set; } = CBManagerState.Unknown;
 
-        public void DidUpdateState(CBCentralManager central) => state = central.State;
+        public void DidUpdateState(CBCentralManager central) => State = central.State;
     }
 
     public class CBCentralManagerTests
@@ -21,34 +21,34 @@ namespace CoreBluetoothTests
         [Test]
         public void Create()
         {
-            using var centralManager = CBCentralManager.Create();
+            using var centralManager = new CBCentralManager();
             Assert.That(centralManager, Is.Not.Null);
         }
 
         [Test]
         public void Release()
         {
-            CBCentralManager centralManager;
-            using (centralManager = CBCentralManager.Create()) { }
+            var centralManager = new CBCentralManager();
+            centralManager.Dispose();
             var delegateMock = new CBCentralManagerDelegateMock();
             Assert.That(() => centralManager.Delegate = delegateMock, Throws.TypeOf<System.ObjectDisposedException>());
         }
 
         [UnityTest]
-        public IEnumerator DidUpdateState_CalledOnCreateAsync()
+        public IEnumerator DidUpdateState_CalledAfterNewAsync()
         {
             var delegateMock = new CBCentralManagerDelegateMock();
-            using var centralManager = CBCentralManager.Create(delegateMock);
-            Assert.That(delegateMock.state, Is.EqualTo(CBManagerState.Unknown));
+            using var centralManager = new CBCentralManager(delegateMock);
+            Assert.That(delegateMock.State, Is.EqualTo(CBManagerState.Unknown));
 
-            yield return WaitUntilWithTimeout(() => delegateMock.state != CBManagerState.Unknown, 1f);
-            Assert.That(delegateMock.state, Is.Not.EqualTo(CBManagerState.Unknown));
+            yield return WaitUntilWithTimeout(() => delegateMock.State != CBManagerState.Unknown, 1f);
+            Assert.That(delegateMock.State, Is.Not.EqualTo(CBManagerState.Unknown));
         }
 
         [UnityTest]
         public IEnumerator ScanForPeripherals_InvalidServiceUUID_Throw()
         {
-            using var centralManager = CBCentralManager.Create();
+            using var centralManager = new CBCentralManager();
             yield return WaitUntilWithTimeout(() => centralManager.State != CBManagerState.Unknown, 1f);
             if (centralManager.State != CBManagerState.PoweredOn) yield break;
 
@@ -58,7 +58,7 @@ namespace CoreBluetoothTests
         [UnityTest]
         public IEnumerator ScanStartStop()
         {
-            using var centralManager = CBCentralManager.Create();
+            using var centralManager = new CBCentralManager();
             yield return WaitUntilWithTimeout(() => centralManager.State != CBManagerState.Unknown, 1f);
             if (centralManager.State != CBManagerState.PoweredOn) yield break;
 


### PR DESCRIPTION
## Description

CentralManagerをインスタンス化するためにstaticメソッドでやるのをやめる

## Related
https://github.com/teach310/CoreBluetoothForUnity/pull/19/commits/8abeb1e06172ebb26eef5b9de3e0eb284c9715b8