### PR TITLE
refactor: _new return SafeHandle

### DIFF
--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMethods.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMethods.cs
@@ -25,7 +25,7 @@ namespace CoreBluetooth
         internal static extern int cb4u_central_maximum_update_value_length(SafeNativeCentralHandle handle);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr cb4u_central_manager_new();
+        internal static extern SafeNativeCentralManagerHandle cb4u_central_manager_new();
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void cb4u_central_manager_release(IntPtr handle);
@@ -146,7 +146,7 @@ namespace CoreBluetooth
         );
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr cb4u_peripheral_manager_new();
+        internal static extern SafeNativePeripheralManagerHandle cb4u_peripheral_manager_new();
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void cb4u_peripheral_manager_release(IntPtr handle);
@@ -192,7 +192,7 @@ namespace CoreBluetooth
         internal static extern void cb4u_peripheral_manager_respond_to_request(SafeNativePeripheralManagerHandle peripheralHandle, SafeNativeATTRequestHandle requestPtr, int errorCode);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr cb4u_mutable_service_new([MarshalAs(UnmanagedType.LPStr), In] string uuid, [MarshalAs(UnmanagedType.I1)] bool primary);
+        internal static extern SafeNativeMutableServiceHandle cb4u_mutable_service_new([MarshalAs(UnmanagedType.LPStr), In] string uuid, [MarshalAs(UnmanagedType.I1)] bool primary);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void cb4u_mutable_service_release(IntPtr handle);
@@ -204,7 +204,7 @@ namespace CoreBluetooth
         internal static extern int cb4u_mutable_service_add_characteristic(SafeNativeMutableServiceHandle serviceHandle, SafeNativeMutableCharacteristicHandle characteristicHandle);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr cb4u_mutable_characteristic_new(
+        internal static extern SafeNativeMutableCharacteristicHandle cb4u_mutable_characteristic_new(
             [MarshalAs(UnmanagedType.LPStr), In] string uuid,
             int properties,
             [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 3)] byte[] dataBytes,

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeCentralManagerHandle.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeCentralManagerHandle.cs
@@ -1,23 +1,21 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace CoreBluetooth
 {
-    internal class SafeNativeCentralManagerHandle : SafeHandle
+    internal class SafeNativeCentralManagerHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         static Dictionary<IntPtr, CBCentralManager> s_centralManagerMap = new Dictionary<IntPtr, CBCentralManager>();
 
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        SafeNativeCentralManagerHandle(IntPtr handle) : base(handle, true) { }
+        SafeNativeCentralManagerHandle() : base(true) { }
 
         internal static SafeNativeCentralManagerHandle Create(CBCentralManager centralManager)
         {
-            var handle = NativeMethods.cb4u_central_manager_new();
-            var instance = new SafeNativeCentralManagerHandle(handle);
+            var instance = NativeMethods.cb4u_central_manager_new();
             RegisterHandlers(instance);
-            s_centralManagerMap.Add(handle, centralManager);
+            s_centralManagerMap.Add(instance.handle, centralManager);
             return instance;
         }
 

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeMutableCharacteristicHandle.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeMutableCharacteristicHandle.cs
@@ -1,13 +1,10 @@
-using System;
-using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace CoreBluetooth
 {
-    internal class SafeNativeMutableCharacteristicHandle : SafeHandle
+    internal class SafeNativeMutableCharacteristicHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        SafeNativeMutableCharacteristicHandle(IntPtr handle) : base(handle, true) { }
+        SafeNativeMutableCharacteristicHandle() : base(true) { }
 
         internal static SafeNativeMutableCharacteristicHandle Create(
             string uuid,
@@ -16,13 +13,12 @@ namespace CoreBluetooth
             CBAttributePermissions permissions
         )
         {
-            var handle = NativeMethods.cb4u_mutable_characteristic_new(uuid,
+            return NativeMethods.cb4u_mutable_characteristic_new(
+                uuid,
                 (int)properties,
                 value,
                 value?.Length ?? 0,
                 (int)permissions);
-            var instance = new SafeNativeMutableCharacteristicHandle(handle);
-            return instance;
         }
 
         protected override bool ReleaseHandle()

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeMutableServiceHandle.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativeMutableServiceHandle.cs
@@ -1,19 +1,14 @@
-using System;
-using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace CoreBluetooth
 {
-    internal class SafeNativeMutableServiceHandle : SafeHandle
+    internal class SafeNativeMutableServiceHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        SafeNativeMutableServiceHandle(IntPtr handle) : base(handle, true) { }
+        SafeNativeMutableServiceHandle() : base(true) { }
 
         internal static SafeNativeMutableServiceHandle Create(string uuid, bool isPrimary)
         {
-            var handle = NativeMethods.cb4u_mutable_service_new(uuid, isPrimary);
-            var instance = new SafeNativeMutableServiceHandle(handle);
-            return instance;
+            return NativeMethods.cb4u_mutable_service_new(uuid, isPrimary);
         }
 
         protected override bool ReleaseHandle()

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativePeripheralManagerHandle.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativePeripheralManagerHandle.cs
@@ -1,23 +1,20 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 namespace CoreBluetooth
 {
-    public class SafeNativePeripheralManagerHandle : SafeHandle
+    public class SafeNativePeripheralManagerHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         static Dictionary<IntPtr, CBPeripheralManager> s_peripheralManagerMap = new Dictionary<IntPtr, CBPeripheralManager>();
 
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        SafeNativePeripheralManagerHandle(IntPtr handle) : base(handle, true) { }
+        SafeNativePeripheralManagerHandle() : base(true) { }
 
         internal static SafeNativePeripheralManagerHandle Create(CBPeripheralManager peripheralManager)
         {
-            var handle = NativeMethods.cb4u_peripheral_manager_new();
-            var instance = new SafeNativePeripheralManagerHandle(handle);
+            var instance = NativeMethods.cb4u_peripheral_manager_new();
             RegisterHandlers(instance);
-            s_peripheralManagerMap.Add(handle, peripheralManager);
+            s_peripheralManagerMap.Add(instance.handle, peripheralManager);
             return instance;
         }
 


### PR DESCRIPTION
refactor: _newでswiftのクラスを生成する場合にはSafeHandleを返すようにする

その際コンストラクタは引数なしである必要があるためSafeHandleZeroOrMinusOneIsInvalidを使用

SafeHandleのドキュメントでもnewではSafeHandleが返るようになっている
https://learn.microsoft.com/ja-jp/dotnet/api/system.runtime.interopservices.safehandle?view=netframework-4.8

コールバックで生成したものを返すものに関しては以下のエラーが出て動かなかった。
mono/marshal: SafeHandles missing MANAGED_CONV_IN