### PR TITLE
remove INativeXXX interfaces

### DIFF
--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBATTRequest.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBATTRequest.cs
@@ -2,15 +2,6 @@ using System;
 
 namespace CoreBluetooth
 {
-    internal interface INativeATTRequest
-    {
-        CBCentral Central { get; }
-        CBCharacteristic Characteristic { get; }
-        byte[] Value { get; }
-        void SetValue(byte[] value);
-        int Offset { get; }
-    }
-
     /// <summary>
     /// A request that uses the Attribute Protocol (ATT).
     /// https://developer.apple.com/documentation/corebluetooth/cbattrequest
@@ -19,7 +10,7 @@ namespace CoreBluetooth
     {
         bool _disposed = false;
         internal SafeNativeATTRequestHandle Handle { get; }
-        INativeATTRequest _nativeATTRequest = null;
+        NativeATTRequestProxy _nativeATTRequest = null;
 
         public CBCentral Central
         {
@@ -62,7 +53,7 @@ namespace CoreBluetooth
             }
         }
 
-        internal CBATTRequest(SafeNativeATTRequestHandle handle, INativeATTRequest nativeATTRequest)
+        internal CBATTRequest(SafeNativeATTRequestHandle handle, NativeATTRequestProxy nativeATTRequest)
         {
             Handle = handle;
             _nativeATTRequest = nativeATTRequest;

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBATTRequests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBATTRequests.cs
@@ -3,16 +3,11 @@ using System.Linq;
 
 namespace CoreBluetooth
 {
-    internal interface INativeATTRequests
-    {
-        CBATTRequest[] GetRequests();
-    }
-
     internal class CBATTRequests : IDisposable
     {
         bool _disposed = false;
         SafeNativeATTRequestsHandle _handle;
-        INativeATTRequests _nativeATTRequests;
+        NativeATTRequestsProxy _nativeATTRequests;
 
         CBATTRequest[] _requests = null;
         public CBATTRequest[] Requests
@@ -28,7 +23,7 @@ namespace CoreBluetooth
             }
         }
 
-        internal CBATTRequests(SafeNativeATTRequestsHandle handle, INativeATTRequests nativeATTRequests)
+        internal CBATTRequests(SafeNativeATTRequestsHandle handle, NativeATTRequestsProxy nativeATTRequests)
         {
             _handle = handle;
             _nativeATTRequests = nativeATTRequests;

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentral.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCentral.cs
@@ -2,12 +2,6 @@ using System;
 
 namespace CoreBluetooth
 {
-    internal interface INativeCentral
-    {
-        string Identifier { get; }
-        int MaximumUpdateValueLength { get; }
-    }
-
     /// <summary>
     /// A remote device connected to a local app, which is acting as a peripheral.
     /// https://developer.apple.com/documentation/corebluetooth/cbcentral
@@ -16,7 +10,7 @@ namespace CoreBluetooth
     {
         bool _disposed = false;
         internal SafeNativeCentralHandle Handle { get; }
-        INativeCentral _nativeCentral = null;
+        NativeCentralProxy _nativeCentral = null;
 
         string _identifier = null;
         public string Identifier

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCharacteristic.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBCharacteristic.cs
@@ -23,11 +23,6 @@ namespace CoreBluetooth
         WithoutResponse
     }
 
-    internal interface INativeCharacteristic
-    {
-        CBCharacteristicProperties Properties { get; }
-    }
-
     /// <summary>
     /// A characteristic of a remote peripheral’s service.
     /// https://developer.apple.com/documentation/corebluetooth/cbcharacteristic
@@ -54,19 +49,19 @@ namespace CoreBluetooth
 
         public virtual CBCharacteristicProperties Properties
         {
-            get => nativeCharacteristic.Properties;
+            get => _nativeCharacteristic.Properties;
             set => throw new NotImplementedException(s_notImplementedExceptionMessage);
         }
 
         public bool IsNotifying { get; private set; } = false;
         internal void UpdateIsNotifying(bool isNotifying) => IsNotifying = isNotifying;
 
-        private protected INativeCharacteristic nativeCharacteristic;
+        NativeCharacteristicProxy _nativeCharacteristic;
 
-        internal CBCharacteristic(string uuid, INativeCharacteristic nativeCharacteristic)
+        internal CBCharacteristic(string uuid, NativeCharacteristicProxy nativeCharacteristic)
         {
             this.UUID = uuid;
-            this.nativeCharacteristic = nativeCharacteristic;
+            _nativeCharacteristic = nativeCharacteristic;
         }
 
         public override string ToString()

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBMutableCharacteristic.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBMutableCharacteristic.cs
@@ -5,15 +5,6 @@ using UnityEngine;
 
 namespace CoreBluetooth
 {
-    internal interface INativeMutableCharacteristic : INativeCharacteristic
-    {
-        byte[] Value { get; }
-        void SetValue(byte[] value);
-        void SetProperties(CBCharacteristicProperties properties);
-        CBAttributePermissions Permissions { get; }
-        void SetPermissions(CBAttributePermissions permissions);
-    }
-
     /// <summary>
     /// A characteristic of a local peripheral’s service.
     /// https://developer.apple.com/documentation/corebluetooth/cbmutablecharacteristic
@@ -22,7 +13,7 @@ namespace CoreBluetooth
     {
         bool _disposed = false;
         internal SafeNativeMutableCharacteristicHandle Handle { get; }
-        INativeMutableCharacteristic _nativeMutableCharacteristic = null;
+        NativeMutableCharacteristicProxy _nativeMutableCharacteristic = null;
 
         public override byte[] Value
         {
@@ -75,7 +66,6 @@ namespace CoreBluetooth
         {
             Handle = SafeNativeMutableCharacteristicHandle.Create(uuid, properties, value, permissions);
             _nativeMutableCharacteristic = new NativeMutableCharacteristicProxy(Handle);
-            nativeCharacteristic = _nativeMutableCharacteristic;
         }
 
         public override string ToString()

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBMutableService.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBMutableService.cs
@@ -2,11 +2,6 @@ using System;
 
 namespace CoreBluetooth
 {
-    internal interface INativeMutableService
-    {
-        void SetCharacteristics(CBCharacteristic[] characteristics);
-    }
-
     /// <summary>
     /// A service with writeable property values.
     /// https://developer.apple.com/documentation/corebluetooth/cbmutableservice
@@ -15,7 +10,7 @@ namespace CoreBluetooth
     {
         bool _disposed = false;
         internal SafeNativeMutableServiceHandle Handle { get; }
-        readonly INativeMutableService _nativeMutableService;
+        readonly NativeMutableServiceProxy _nativeMutableService;
 
         public override CBCharacteristic[] Characteristics
         {

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBPeripheral.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBPeripheral.cs
@@ -13,18 +13,6 @@ namespace CoreBluetooth
         Disconnecting
     }
 
-    internal interface INativePeripheral
-    {
-        string Identifier { get; }
-        string Name { get; }
-        void DiscoverServices(string[] serviceUUIDs);
-        void DiscoverCharacteristics(string[] characteristicUUIDs, CBService service);
-        void ReadValue(CBCharacteristic characteristic);
-        void WriteValue(byte[] data, CBCharacteristic characteristic, CBCharacteristicWriteType type);
-        void SetNotifyValue(bool enabled, CBCharacteristic characteristic);
-        CBPeripheralState State { get; }
-    }
-
     public interface ICBPeripheralDelegate
     {
         void DidDiscoverServices(CBPeripheral peripheral, CBError error) { }
@@ -42,7 +30,7 @@ namespace CoreBluetooth
     {
         bool _disposed = false;
         internal SafeNativePeripheralHandle Handle { get; }
-        INativePeripheral _nativePeripheral = null;
+        NativePeripheralProxy _nativePeripheral = null;
 
         string _identifier = null;
         public string Identifier

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeATTRequestProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeATTRequestProxy.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace CoreBluetooth
 {
-    internal class NativeATTRequestProxy : INativeATTRequest
+    internal class NativeATTRequestProxy
     {
         SafeNativeATTRequestHandle _handle;
         IPeripheralManagerData _peripheralManagerData;
@@ -13,7 +13,7 @@ namespace CoreBluetooth
             _peripheralManagerData = peripheralManagerData;
         }
 
-        CBCentral INativeATTRequest.Central
+        internal CBCentral Central
         {
             get
             {
@@ -39,7 +39,7 @@ namespace CoreBluetooth
             return new CBCentral(centralHandle);
         }
 
-        CBCharacteristic INativeATTRequest.Characteristic
+        internal CBCharacteristic Characteristic
         {
             get
             {
@@ -56,7 +56,7 @@ namespace CoreBluetooth
             }
         }
 
-        byte[] INativeATTRequest.Value
+        internal byte[] Value
         {
             get
             {
@@ -72,11 +72,11 @@ namespace CoreBluetooth
             }
         }
 
-        void INativeATTRequest.SetValue(byte[] value)
+        internal void SetValue(byte[] value)
         {
             NativeMethods.cb4u_att_request_set_value(_handle, value, value?.Length ?? 0);
         }
 
-        int INativeATTRequest.Offset => NativeMethods.cb4u_att_request_offset(_handle);
+        internal int Offset => NativeMethods.cb4u_att_request_offset(_handle);
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeATTRequestsProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeATTRequestsProxy.cs
@@ -1,6 +1,6 @@
 namespace CoreBluetooth
 {
-    internal class NativeATTRequestsProxy : INativeATTRequests
+    internal class NativeATTRequestsProxy
     {
         SafeNativeATTRequestsHandle _handle;
         IPeripheralManagerData _peripheralManagerData;
@@ -11,7 +11,7 @@ namespace CoreBluetooth
             _peripheralManagerData = peripheralManagerData;
         }
 
-        CBATTRequest[] INativeATTRequests.GetRequests()
+        internal CBATTRequest[] GetRequests()
         {
             int count = NativeMethods.cb4u_att_requests_count(_handle);
             CBATTRequest[] requests = new CBATTRequest[count];

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCentralProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCentralProxy.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace CoreBluetooth
 {
-    public class NativeCentralProxy : INativeCentral
+    internal class NativeCentralProxy
     {
         SafeNativeCentralHandle _handle;
 
@@ -11,7 +11,7 @@ namespace CoreBluetooth
             _handle = handle;
         }
 
-        public string Identifier
+        internal string Identifier
         {
             get
             {
@@ -21,6 +21,6 @@ namespace CoreBluetooth
             }
         }
 
-        public int MaximumUpdateValueLength => NativeMethods.cb4u_central_maximum_update_value_length(_handle);
+        internal int MaximumUpdateValueLength => NativeMethods.cb4u_central_maximum_update_value_length(_handle);
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCharacteristicProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCharacteristicProxy.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace CoreBluetooth
 {
-    internal class NativeCharacteristicProxy : INativeCharacteristic
+    internal class NativeCharacteristicProxy
     {
         string _serviceUUID;
         string _characteristicUUID;
@@ -15,7 +15,7 @@ namespace CoreBluetooth
             _handle = handle;
         }
 
-        CBCharacteristicProperties INativeCharacteristic.Properties
+        internal CBCharacteristicProperties Properties
         {
             get
             {

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMutableCharacteristicProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMutableCharacteristicProxy.cs
@@ -1,6 +1,6 @@
 namespace CoreBluetooth
 {
-    internal class NativeMutableCharacteristicProxy : INativeMutableCharacteristic
+    internal class NativeMutableCharacteristicProxy
     {
         SafeNativeMutableCharacteristicHandle _handle;
 
@@ -9,7 +9,7 @@ namespace CoreBluetooth
             _handle = handle;
         }
 
-        byte[] INativeMutableCharacteristic.Value
+        internal byte[] Value
         {
             get
             {
@@ -25,12 +25,12 @@ namespace CoreBluetooth
             }
         }
 
-        void INativeMutableCharacteristic.SetValue(byte[] value)
+        internal void SetValue(byte[] value)
         {
             NativeMethods.cb4u_mutable_characteristic_set_value(_handle, value, value?.Length ?? 0);
         }
 
-        CBCharacteristicProperties INativeCharacteristic.Properties
+        internal CBCharacteristicProperties Properties
         {
             get
             {
@@ -39,7 +39,7 @@ namespace CoreBluetooth
             }
         }
 
-        CBAttributePermissions INativeMutableCharacteristic.Permissions
+        internal CBAttributePermissions Permissions
         {
             get
             {
@@ -48,12 +48,12 @@ namespace CoreBluetooth
             }
         }
 
-        void INativeMutableCharacteristic.SetProperties(CBCharacteristicProperties properties)
+        internal void SetProperties(CBCharacteristicProperties properties)
         {
             NativeMethods.cb4u_mutable_characteristic_set_properties(_handle, (int)properties);
         }
 
-        void INativeMutableCharacteristic.SetPermissions(CBAttributePermissions permissions)
+        internal void SetPermissions(CBAttributePermissions permissions)
         {
             NativeMethods.cb4u_mutable_characteristic_set_permissions(_handle, (int)permissions);
         }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMutableServiceProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMutableServiceProxy.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace CoreBluetooth
 {
-    internal class NativeMutableServiceProxy : INativeMutableService
+    internal class NativeMutableServiceProxy
     {
         SafeNativeMutableServiceHandle _handle;
 
@@ -11,7 +11,7 @@ namespace CoreBluetooth
             _handle = handle;
         }
 
-        void INativeMutableService.SetCharacteristics(CBCharacteristic[] characteristics)
+        internal void SetCharacteristics(CBCharacteristic[] characteristics)
         {
             if (characteristics == null)
             {
@@ -41,6 +41,5 @@ namespace CoreBluetooth
             }
             return mutableCharacteristic;
         }
-
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativePeripheralProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativePeripheralProxy.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace CoreBluetooth
 {
-    internal class NativePeripheralProxy : INativePeripheral
+    internal class NativePeripheralProxy
     {
         readonly SafeNativePeripheralHandle _handle;
 
@@ -13,7 +13,7 @@ namespace CoreBluetooth
             _handle.SetDelegate(peripheralDelegate);
         }
 
-        string INativePeripheral.Identifier
+        internal string Identifier
         {
             get
             {
@@ -23,7 +23,7 @@ namespace CoreBluetooth
             }
         }
 
-        string INativePeripheral.Name
+        internal string Name
         {
             get
             {
@@ -38,7 +38,7 @@ namespace CoreBluetooth
             }
         }
 
-        void INativePeripheral.DiscoverServices(string[] serviceUUIDs)
+        internal void DiscoverServices(string[] serviceUUIDs)
         {
             if (serviceUUIDs != null)
             {
@@ -55,7 +55,7 @@ namespace CoreBluetooth
             );
         }
 
-        void INativePeripheral.DiscoverCharacteristics(string[] characteristicUUIDs, CBService service)
+        internal void DiscoverCharacteristics(string[] characteristicUUIDs, CBService service)
         {
             if (characteristicUUIDs != null)
             {
@@ -75,7 +75,7 @@ namespace CoreBluetooth
             ExceptionUtils.ThrowIfServiceNotFound(result, service.UUID);
         }
 
-        void INativePeripheral.ReadValue(CBCharacteristic characteristic)
+        internal void ReadValue(CBCharacteristic characteristic)
         {
             int result = NativeMethods.cb4u_peripheral_read_characteristic_value(
                 _handle,
@@ -87,7 +87,7 @@ namespace CoreBluetooth
             ExceptionUtils.ThrowIfCharacteristicNotFound(result, characteristic.UUID);
         }
 
-        void INativePeripheral.WriteValue(byte[] data, CBCharacteristic characteristic, CBCharacteristicWriteType writeType)
+        internal void WriteValue(byte[] data, CBCharacteristic characteristic, CBCharacteristicWriteType writeType)
         {
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
@@ -106,7 +106,7 @@ namespace CoreBluetooth
             ExceptionUtils.ThrowIfCharacteristicNotFound(result, characteristic.UUID);
         }
 
-        void INativePeripheral.SetNotifyValue(bool enabled, CBCharacteristic characteristic)
+        internal void SetNotifyValue(bool enabled, CBCharacteristic characteristic)
         {
             int result = NativeMethods.cb4u_peripheral_set_notify_value(
                 _handle,
@@ -119,7 +119,7 @@ namespace CoreBluetooth
             ExceptionUtils.ThrowIfCharacteristicNotFound(result, characteristic.UUID);
         }
 
-        CBPeripheralState INativePeripheral.State
+        internal CBPeripheralState State
         {
             get
             {


### PR DESCRIPTION
## なぜこのインターフェースがあったのか
Nativeに依存せずにテストするために必要だと考えていた。

## 消す理由
Nativeに依存しないテストを現状書いておらず、今のところ書く予定もないため意味がない。
手間が増えているだけで早すぎる抽象化であると感じた。

必要になったら追加すればいい、現状では削除すべきと判断。