### PR TITLE
remove throw on callback

### DIFF
--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativePeripheralHandle.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/SafeNativePeripheralHandle.cs
@@ -69,11 +69,6 @@ namespace CoreBluetooth
         internal static void DidDiscoverServices(IntPtr peripheralPtr, IntPtr commaSeparatedServiceUUIDsPtr, int errorCode)
         {
             string commaSeparatedServiceUUIDs = Marshal.PtrToStringUTF8(commaSeparatedServiceUUIDsPtr);
-            if (string.IsNullOrEmpty(commaSeparatedServiceUUIDs))
-            {
-                throw new ArgumentException("commaSeparatedServiceUUIDs is null or empty.");
-            }
-
             GetDelegate(peripheralPtr)?.DidDiscoverServices(
                 commaSeparatedServiceUUIDs.Split(','),
                 CBError.CreateOrNullFromCode(errorCode)
@@ -84,11 +79,6 @@ namespace CoreBluetooth
         internal static void DidDiscoverCharacteristics(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr commaSeparatedCharacteristicUUIDsPtr, int errorCode)
         {
             string commaSeparatedCharacteristicUUIDs = Marshal.PtrToStringUTF8(commaSeparatedCharacteristicUUIDsPtr);
-            if (string.IsNullOrEmpty(commaSeparatedCharacteristicUUIDs))
-            {
-                throw new ArgumentException("commaSeparatedCharacteristicUUIDs is null or empty.");
-            }
-
             GetDelegate(peripheralPtr)?.DidDiscoverCharacteristics(
                 Marshal.PtrToStringUTF8(serviceUUIDPtr),
                 commaSeparatedCharacteristicUUIDs.Split(','),
@@ -156,11 +146,6 @@ namespace CoreBluetooth
         internal static void DidModifyServices(IntPtr peripheralPtr, IntPtr commaSeparatedServiceUUIDsPtr)
         {
             string commaSeparatedServiceUUIDs = Marshal.PtrToStringUTF8(commaSeparatedServiceUUIDsPtr);
-            if (string.IsNullOrEmpty(commaSeparatedServiceUUIDs))
-            {
-                throw new ArgumentException("commaSeparatedServiceUUIDs is null or empty.");
-            }
-
             GetDelegate(peripheralPtr)?.DidModifyServices(
                 commaSeparatedServiceUUIDs.Split(',')
             );


### PR DESCRIPTION
コールバックでcontext変えるまえにエラー投げるとUnityがクラッシュするため。

DidDiscoverCharacteristicsはCharacteristicが見つからなかった場合も呼ばれて空が渡される仕様なためそもそもthrowすべきでない。 他はおそらく空なことはないため異常だとは思うが、空の配列が渡った先でthrowする必要性は感じなかったためそのまま削除