### PR TITLE
set overrideReferences true

### DIFF
--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CoreBluetooth.asmdef
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CoreBluetooth.asmdef
@@ -9,7 +9,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],


### PR DESCRIPTION
## Description
csproj の容量と依存を減らす試み

override preferences をtrueにすることでReferencesが減り、デメリットもなかった https://docs.unity3d.com/ja/2022.2/Manual/ScriptCompilationAssemblyDefinitionFiles.html

## No Engine Referencesが外せない件について

No Engine References を true にするとUnityEngineへの参照がなくなるためドキュメントの生成が楽になる。 ただし、これはできなかった。

AOT.MonoPInvokeCallback
がUnityEngineに依存しているため。