### PR TITLE
fix compile error on Win, Linus

### DIFF
--- a/Assets/CoreBluetooth/Samples/11_BuildPostprocessor/Editor/BuildPostprocessor.cs
+++ b/Assets/CoreBluetooth/Samples/11_BuildPostprocessor/Editor/BuildPostprocessor.cs
@@ -5,7 +5,9 @@ using System.IO;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
+#if UNITY_IOS
 using UnityEditor.iOS.Xcode;
+#endif
 using UnityEngine;
 
 namespace CoreBluetoothEditor
@@ -16,6 +18,7 @@ namespace CoreBluetoothEditor
 
         public void OnPostprocessBuild(BuildReport report)
         {
+#if UNITY_IOS
             var buildTarget = report.summary.platform;
             if (buildTarget == BuildTarget.iOS)
             {
@@ -23,8 +26,10 @@ namespace CoreBluetoothEditor
             }
 
             Debug.Log("BuildPostprocessor.OnPostprocessBuild for target " + report.summary.platform + " at path " + report.summary.outputPath);
+#endif
         }
 
+#if UNITY_IOS
         void ProcessForiOS(BuildReport report)
         {
             var buildOutputPath = report.summary.outputPath;
@@ -73,5 +78,6 @@ namespace CoreBluetoothEditor
             var unityFrameworkTargetGuid = project.GetUnityFrameworkTargetGuid();
             project.SetBuildProperty(unityFrameworkTargetGuid, "ENABLE_BITCODE", "NO");
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCentralManagerTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCentralManagerTests.cs
@@ -16,6 +16,7 @@ namespace CoreBluetoothTests
 
     public class CBCentralManagerTests : CBTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void Create()
         {
@@ -88,5 +89,6 @@ namespace CoreBluetoothTests
             Assert.That(peripherals, Is.Not.Null);
             Assert.That(peripherals.Length, Is.EqualTo(0));
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCharacteristicTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBCharacteristicTests.cs
@@ -6,6 +6,7 @@ namespace CoreBluetoothTests
 {
     public class CBCharacteristicTests : CBTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void Value_Set_NotImplemented()
         {
@@ -19,5 +20,6 @@ namespace CoreBluetoothTests
             var characteristic = new CBCharacteristic(validUUID1, null);
             Assert.That(() => characteristic.Properties = CBCharacteristicProperties.Broadcast, Throws.TypeOf<NotImplementedException>());
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBMutableCharacteristicTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBMutableCharacteristicTests.cs
@@ -6,6 +6,7 @@ namespace CoreBluetoothTests
 {
     public class CBMutableCharacteristicTests : CBTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void Create()
         {
@@ -62,5 +63,6 @@ namespace CoreBluetoothTests
             using var characteristic = new CBMutableCharacteristic(validUUID1, CBCharacteristicProperties.Broadcast, null, CBAttributePermissions.Readable);
             Assert.That(characteristic.ToString(), Is.EqualTo($"CBMutableCharacteristic: UUID = {validUUID1}, properties = Broadcast, value = null, notifying = NO, permissions = Readable"));
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBMutableServiceTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBMutableServiceTests.cs
@@ -6,6 +6,7 @@ namespace CoreBluetoothTests
 {
     public class CBMutableServiceTests : CBTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void Create()
         {
@@ -40,5 +41,6 @@ namespace CoreBluetoothTests
                 item.Dispose();
             }
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBPeripheralManagerTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBPeripheralManagerTests.cs
@@ -25,6 +25,7 @@ namespace CoreBluetoothTests
 
     public class CBPeripheralManagerTests : CBTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void Create()
         {
@@ -176,5 +177,6 @@ namespace CoreBluetoothTests
             Assert.That(delegateMock.DidStartAdvertisingCount, Is.EqualTo(2));
             Assert.That(delegateMock.Error.ErrorCode, Is.EqualTo(CBError.Code.AlreadyAdvertising));
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBServiceTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/CBServiceTests.cs
@@ -6,6 +6,7 @@ namespace CoreBluetoothTests
 {
     public class CBServiceTests : CBTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void Characteristics_Set_NotImplemented()
         {
@@ -36,5 +37,6 @@ namespace CoreBluetoothTests
             service.UpdateCharacteristics(null);
             Assert.That(service.Characteristics, Is.Null);
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSArrayTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSArrayTests.cs
@@ -5,6 +5,7 @@ namespace CoreBluetoothTests.Foundation
 {
     public class NSArrayTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void FromStrings()
         {
@@ -20,5 +21,6 @@ namespace CoreBluetoothTests.Foundation
             var strings = NSArray.StringsFromHandle(nsArray.Handle);
             Assert.That(strings, Is.EqualTo(new[] { "hoge", "fuga" }));
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSMutableDictionaryTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSMutableDictionaryTests.cs
@@ -5,6 +5,7 @@ namespace CoreBluetoothTests.Foundation
 {
     public class NSMutableDictionaryTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void New()
         {
@@ -51,5 +52,6 @@ namespace CoreBluetoothTests.Foundation
             using var notFoundKey = new NSString("dummy");
             Assert.That(nsDictionary.TryGetValue(notFoundKey.Handle, out gotPtr), Is.False);
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSNumberTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSNumberTests.cs
@@ -5,6 +5,7 @@ namespace CoreBluetoothTests.Foundation
 {
     public class NSNumberTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void IntValue()
         {
@@ -27,5 +28,6 @@ namespace CoreBluetoothTests.Foundation
             Assert.That(falseNumber.Handle.IsInvalid, Is.False);
             Assert.That(falseNumber.BoolValue, Is.False);
         }
+#endif
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSStringTests.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Tests/Runtime/Foundation/NSStringTests.cs
@@ -5,6 +5,7 @@ namespace CoreBluetoothTests.Foundation
 {
     public class NSStringTests
     {
+#if UNITY_IOS || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
         [Test]
         public void New()
         {
@@ -50,5 +51,6 @@ namespace CoreBluetoothTests.Foundation
                 Assert.That(NSString.HandleToString(nsString.Handle), Is.EqualTo(string.Empty));
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
## Description
アセンブリの設定でEditorで使えるようにしているため、MacOSだけでなく、WindowsやLinuxでも使えてしまう。
MacOSでしか動かないため、その他ではコンパイルされないように設定