### PR TITLE
add NativeCallbacks Class to avoid depending on UnityEngine

### DIFF
--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBMutableCharacteristic.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/CBMutableCharacteristic.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace CoreBluetooth
 {

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs
@@ -9,6 +9,7 @@ namespace CoreBluetooth
         {
             ServiceLocator.Instance.Register<INativeCentralManagerCallbacks>(new NativeCentralManagerCallbacks());
             ServiceLocator.Instance.Register<INativePeripheralManagerCallbacks>(new NativePeripheralManagerCallbacks());
+            ServiceLocator.Instance.Register<INativePeripheralCallbacks>(new NativePeripheralCallbacks());
         }
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace CoreBluetooth
+{
+    internal class Initializer
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        static void Initialize()
+        {
+            ServiceLocator.Instance.Register<INativeCentralManagerCallbacks>(new NativeCentralManagerCallbacks());
+        }
+    }
+}

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs
@@ -8,6 +8,7 @@ namespace CoreBluetooth
         static void Initialize()
         {
             ServiceLocator.Instance.Register<INativeCentralManagerCallbacks>(new NativeCentralManagerCallbacks());
+            ServiceLocator.Instance.Register<INativePeripheralManagerCallbacks>(new NativePeripheralManagerCallbacks());
         }
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs.meta
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/Initializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac3bce9747e914f5980212a50bfb4e48
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks.meta
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4a8784e988b834584b3d2e5e2e6b074e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativeCentralManagerCallbacks.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativeCentralManagerCallbacks.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace CoreBluetooth
+{
+    internal class NativeCentralManagerCallbacks : INativeCentralManagerCallbacks
+    {
+        readonly static Dictionary<IntPtr, INativeCentralManagerDelegate> s_centralManagerDelegateMap = new Dictionary<IntPtr, INativeCentralManagerDelegate>();
+
+        public void Register(SafeNativeCentralManagerHandle handle, INativeCentralManagerDelegate centralManagerDelegate)
+        {
+            s_centralManagerDelegateMap[handle.DangerousGetHandle()] = centralManagerDelegate;
+            NativeMethods.cb4u_central_manager_register_handlers(
+                handle,
+                DidConnect,
+                DidDisconnectPeripheral,
+                DidFailToConnect,
+                DidDiscoverPeripheral,
+                DidUpdateState
+            );
+        }
+
+        public void Unregister(SafeNativeCentralManagerHandle handle)
+        {
+            s_centralManagerDelegateMap.Remove(handle.DangerousGetHandle());
+        }
+
+        static INativeCentralManagerDelegate GetDelegate(IntPtr centralPtr)
+        {
+            return s_centralManagerDelegateMap.GetValueOrDefault(centralPtr);
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidConnectHandler))]
+        static void DidConnect(IntPtr centralPtr, IntPtr peripheralIdPtr)
+        {
+            GetDelegate(centralPtr)?.DidConnect(Marshal.PtrToStringUTF8(peripheralIdPtr));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidDisconnectPeripheralHandler))]
+        static void DidDisconnectPeripheral(IntPtr centralPtr, IntPtr peripheralIdPtr, int errorCode)
+        {
+            GetDelegate(centralPtr)?.DidDisconnectPeripheral(
+                Marshal.PtrToStringUTF8(peripheralIdPtr),
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidFailToConnectHandler))]
+        static void DidFailToConnect(IntPtr centralPtr, IntPtr peripheralIdPtr, int errorCode)
+        {
+            GetDelegate(centralPtr)?.DidFailToConnect(
+                Marshal.PtrToStringUTF8(peripheralIdPtr),
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidDiscoverPeripheralHandler))]
+        static void DidDiscoverPeripheral(IntPtr centralPtr, IntPtr peripheralPtr, int rssi)
+        {
+            GetDelegate(centralPtr)?.DidDiscoverPeripheral(
+                new SafeNativePeripheralHandle(peripheralPtr),
+                rssi
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidUpdateStateHandler))]
+        static void DidUpdateState(IntPtr centralPtr, CBManagerState state)
+        {
+            GetDelegate(centralPtr)?.DidUpdateState(state);
+        }
+    }
+}

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativeCentralManagerCallbacks.cs.meta
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativeCentralManagerCallbacks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cebdd2a683bf44a3d8287b2d184259bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralCallbacks.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralCallbacks.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace CoreBluetooth
+{
+    internal class NativePeripheralCallbacks : INativePeripheralCallbacks
+    {
+        readonly static Dictionary<IntPtr, INativePeripheralDelegate> s_nativePeripheralDelegateMap = new Dictionary<IntPtr, INativePeripheralDelegate>();
+
+        public void Register(SafeNativePeripheralHandle handle, INativePeripheralDelegate peripheralDelegate)
+        {
+            s_nativePeripheralDelegateMap[handle.DangerousGetHandle()] = peripheralDelegate;
+            NativeMethods.cb4u_peripheral_register_handlers(
+                handle,
+                DidDiscoverServices,
+                DidDiscoverCharacteristics,
+                DidUpdateValueForCharacteristic,
+                DidWriteValueForCharacteristic,
+                IsReadyToSendWriteWithoutResponse,
+                DidUpdateNotificationStateForCharacteristic,
+                DidReadRSSI,
+                DidUpdateName,
+                DidModifyServices
+            );
+        }
+
+        public void Unregister(SafeNativePeripheralHandle handle)
+        {
+            s_nativePeripheralDelegateMap.Remove(handle.DangerousGetHandle());
+        }
+
+        static INativePeripheralDelegate GetDelegate(IntPtr peripheralPtr)
+        {
+            return s_nativePeripheralDelegateMap.GetValueOrDefault(peripheralPtr);
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidDiscoverServicesHandler))]
+        public static void DidDiscoverServices(IntPtr peripheralPtr, IntPtr commaSeparatedServiceUUIDsPtr, int errorCode)
+        {
+            string commaSeparatedServiceUUIDs = Marshal.PtrToStringUTF8(commaSeparatedServiceUUIDsPtr);
+            GetDelegate(peripheralPtr)?.DidDiscoverServices(
+                commaSeparatedServiceUUIDs.Split(','),
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidDiscoverCharacteristicsHandler))]
+        public static void DidDiscoverCharacteristics(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr commaSeparatedCharacteristicUUIDsPtr, int errorCode)
+        {
+            string commaSeparatedCharacteristicUUIDs = Marshal.PtrToStringUTF8(commaSeparatedCharacteristicUUIDsPtr);
+            GetDelegate(peripheralPtr)?.DidDiscoverCharacteristics(
+                Marshal.PtrToStringUTF8(serviceUUIDPtr),
+                commaSeparatedCharacteristicUUIDs.Split(','),
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateValueForCharacteristicHandler))]
+        public static void DidUpdateValueForCharacteristic(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr, IntPtr dataPtr, int dataLength, int errorCode)
+        {
+            var dataBytes = new byte[dataLength];
+            Marshal.Copy(dataPtr, dataBytes, 0, dataLength);
+
+            GetDelegate(peripheralPtr)?.DidUpdateValueForCharacteristic(
+                Marshal.PtrToStringUTF8(serviceUUIDPtr),
+                Marshal.PtrToStringUTF8(characteristicUUIDPtr),
+                dataBytes,
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidWriteValueForCharacteristicHandler))]
+        public static void DidWriteValueForCharacteristic(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr, int errorCode)
+        {
+            GetDelegate(peripheralPtr)?.DidWriteValueForCharacteristic(
+                Marshal.PtrToStringUTF8(serviceUUIDPtr),
+                Marshal.PtrToStringUTF8(characteristicUUIDPtr),
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralIsReadyToSendWriteWithoutResponseHandler))]
+        public static void IsReadyToSendWriteWithoutResponse(IntPtr peripheralPtr)
+        {
+            GetDelegate(peripheralPtr)?.IsReadyToSendWriteWithoutResponse();
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateNotificationStateForCharacteristicHandler))]
+        public static void DidUpdateNotificationStateForCharacteristic(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr, int notificationState, int errorCode)
+        {
+            GetDelegate(peripheralPtr)?.DidUpdateNotificationStateForCharacteristic(
+                Marshal.PtrToStringUTF8(serviceUUIDPtr),
+                Marshal.PtrToStringUTF8(characteristicUUIDPtr),
+                notificationState == 1,
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidReadRSSIHandler))]
+        public static void DidReadRSSI(IntPtr peripheralPtr, int rssi, int errorCode)
+        {
+            GetDelegate(peripheralPtr)?.DidReadRSSI(
+                rssi,
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateNameHandler))]
+        public static void DidUpdateName(IntPtr peripheralPtr)
+        {
+            GetDelegate(peripheralPtr)?.DidUpdateName();
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidModifyServicesHandler))]
+        public static void DidModifyServices(IntPtr peripheralPtr, IntPtr commaSeparatedServiceUUIDsPtr)
+        {
+            string commaSeparatedServiceUUIDs = Marshal.PtrToStringUTF8(commaSeparatedServiceUUIDsPtr);
+            GetDelegate(peripheralPtr)?.DidModifyServices(
+                commaSeparatedServiceUUIDs.Split(',')
+            );
+        }
+    }
+}

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralCallbacks.cs.meta
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralCallbacks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20fa0ebfac1694eb187459a3fd262839
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralManagerCallbacks.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralManagerCallbacks.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace CoreBluetooth
+{
+    internal class NativePeripheralManagerCallbacks : INativePeripheralManagerCallbacks
+    {
+        readonly static Dictionary<IntPtr, INativePeripheralManagerDelegate> s_peripheralManagerDelegateMap = new Dictionary<IntPtr, INativePeripheralManagerDelegate>();
+
+        public void Register(SafeNativePeripheralManagerHandle handle, INativePeripheralManagerDelegate peripheralManagerDelegate)
+        {
+            s_peripheralManagerDelegateMap[handle.DangerousGetHandle()] = peripheralManagerDelegate;
+            NativeMethods.cb4u_peripheral_manager_register_handlers(
+                handle,
+                DidUpdateState,
+                DidAddService,
+                DidStartAdvertising,
+                DidSubscribeToCharacteristic,
+                DidUnsubscribeFromCharacteristic,
+                IsReadyToUpdateSubscribers,
+                DidReceiveReadRequest,
+                DidReceiveWriteRequests
+            );
+        }
+
+        public void Unregister(SafeNativePeripheralManagerHandle handle)
+        {
+            s_peripheralManagerDelegateMap.Remove(handle.DangerousGetHandle());
+        }
+
+        static INativePeripheralManagerDelegate GetDelegate(IntPtr peripheralPtr)
+        {
+            return s_peripheralManagerDelegateMap.GetValueOrDefault(peripheralPtr);
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidUpdateStateHandler))]
+        static void DidUpdateState(IntPtr peripheralPtr, CBManagerState state)
+        {
+            GetDelegate(peripheralPtr)?.DidUpdateState(state);
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidAddServiceHandler))]
+        static void DidAddService(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, int errorCode)
+        {
+            GetDelegate(peripheralPtr)?.DidAddService(
+                Marshal.PtrToStringUTF8(serviceUUIDPtr),
+                CBError.CreateOrNullFromCode(errorCode)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidStartAdvertisingHandler))]
+        static void DidStartAdvertising(IntPtr peripheralPtr, int errorCode)
+        {
+            GetDelegate(peripheralPtr)?.DidStartAdvertising(CBError.CreateOrNullFromCode(errorCode));
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidSubscribeToCharacteristicHandler))]
+        static void DidSubscribeToCharacteristic(IntPtr peripheralPtr, IntPtr centralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr)
+        {
+            GetDelegate(peripheralPtr)?.DidSubscribeToCharacteristic(
+                new SafeNativeCentralHandle(centralPtr),
+                Marshal.PtrToStringUTF8(serviceUUIDPtr),
+                Marshal.PtrToStringUTF8(characteristicUUIDPtr)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidUnsubscribeFromCharacteristicHandler))]
+        static void DidUnsubscribeFromCharacteristic(IntPtr peripheralPtr, IntPtr centralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr)
+        {
+            GetDelegate(peripheralPtr)?.DidUnsubscribeFromCharacteristic(
+                new SafeNativeCentralHandle(centralPtr),
+                Marshal.PtrToStringUTF8(serviceUUIDPtr),
+                Marshal.PtrToStringUTF8(characteristicUUIDPtr)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerIsReadyToUpdateSubscribersHandler))]
+        static void IsReadyToUpdateSubscribers(IntPtr peripheralPtr)
+        {
+            GetDelegate(peripheralPtr)?.IsReadyToUpdateSubscribers();
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidReceiveReadRequestHandler))]
+        static void DidReceiveReadRequest(IntPtr peripheralPtr, IntPtr requestPtr)
+        {
+            GetDelegate(peripheralPtr)?.DidReceiveReadRequest(
+                new SafeNativeATTRequestHandle(requestPtr)
+            );
+        }
+
+        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidReceiveWriteRequestsHandler))]
+        static void DidReceiveWriteRequests(IntPtr peripheralPtr, IntPtr requestsPtr)
+        {
+            GetDelegate(peripheralPtr)?.DidReceiveWriteRequests(
+                new SafeNativeATTRequestsHandle(requestsPtr)
+            );
+        }
+    }
+}

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralManagerCallbacks.cs.meta
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCallbacks/NativePeripheralManagerCallbacks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e86702b2f853478cb8ab72e3e55c33a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCentralManagerProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeCentralManagerProxy.cs
@@ -1,24 +1,27 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace CoreBluetooth
 {
+    internal interface INativeCentralManagerCallbacks
+    {
+        void Register(SafeNativeCentralManagerHandle centralPtr, INativeCentralManagerDelegate centralManagerDelegate);
+        void Unregister(SafeNativeCentralManagerHandle centralPtr);
+    }
+
     internal class NativeCentralManagerProxy : IDisposable
     {
-        readonly static Dictionary<IntPtr, INativeCentralManagerDelegate> s_centralManagerDelegateMap = new Dictionary<IntPtr, INativeCentralManagerDelegate>();
-
         readonly SafeNativeCentralManagerHandle _handle;
+        readonly INativeCentralManagerCallbacks _callbacks;
 
         public NativeCentralManagerProxy(SafeNativeCentralManagerHandle handle, INativeCentralManagerDelegate centralManagerDelegate)
         {
             _handle = handle;
+            _callbacks = ServiceLocator.Instance.Resolve<INativeCentralManagerCallbacks>();
             if (centralManagerDelegate != null)
             {
-                s_centralManagerDelegateMap[handle.DangerousGetHandle()] = centralManagerDelegate;
+                _callbacks.Register(handle, centralManagerDelegate);
             }
-            RegisterHandlers();
         }
 
         public void Connect(CBPeripheral peripheral)
@@ -62,65 +65,9 @@ namespace CoreBluetooth
             return NativeMethods.cb4u_central_manager_is_scanning(_handle);
         }
 
-        void RegisterHandlers()
-        {
-            NativeMethods.cb4u_central_manager_register_handlers(
-                _handle,
-                DidConnect,
-                DidDisconnectPeripheral,
-                DidFailToConnect,
-                DidDiscoverPeripheral,
-                DidUpdateState
-            );
-        }
-
         public void Dispose()
         {
-            s_centralManagerDelegateMap.Remove(_handle.DangerousGetHandle());
-        }
-
-        static INativeCentralManagerDelegate GetDelegate(IntPtr centralPtr)
-        {
-            return s_centralManagerDelegateMap.GetValueOrDefault(centralPtr);
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidConnectHandler))]
-        internal static void DidConnect(IntPtr centralPtr, IntPtr peripheralIdPtr)
-        {
-            GetDelegate(centralPtr)?.DidConnect(Marshal.PtrToStringUTF8(peripheralIdPtr));
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidDisconnectPeripheralHandler))]
-        public static void DidDisconnectPeripheral(IntPtr centralPtr, IntPtr peripheralIdPtr, int errorCode)
-        {
-            GetDelegate(centralPtr)?.DidDisconnectPeripheral(
-                Marshal.PtrToStringUTF8(peripheralIdPtr),
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidFailToConnectHandler))]
-        public static void DidFailToConnect(IntPtr centralPtr, IntPtr peripheralIdPtr, int errorCode)
-        {
-            GetDelegate(centralPtr)?.DidFailToConnect(
-                Marshal.PtrToStringUTF8(peripheralIdPtr),
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidDiscoverPeripheralHandler))]
-        public static void DidDiscoverPeripheral(IntPtr centralPtr, IntPtr peripheralPtr, int rssi)
-        {
-            GetDelegate(centralPtr)?.DidDiscoverPeripheral(
-                new SafeNativePeripheralHandle(peripheralPtr),
-                rssi
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UCentralManagerDidUpdateStateHandler))]
-        public static void DidUpdateState(IntPtr centralPtr, CBManagerState state)
-        {
-            GetDelegate(centralPtr)?.DidUpdateState(state);
+            _callbacks.Unregister(_handle);
         }
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativePeripheralManagerProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativePeripheralManagerProxy.cs
@@ -5,21 +5,25 @@ using System.Runtime.InteropServices;
 
 namespace CoreBluetooth
 {
+    internal interface INativePeripheralManagerCallbacks
+    {
+        void Register(SafeNativePeripheralManagerHandle handle, INativePeripheralManagerDelegate peripheralManagerDelegate);
+        void Unregister(SafeNativePeripheralManagerHandle handle);
+    }
+
     internal class NativePeripheralManagerProxy : IDisposable
     {
-        static Dictionary<IntPtr, INativePeripheralManagerDelegate> s_peripheralManagerDelegateMap = new Dictionary<IntPtr, INativePeripheralManagerDelegate>();
-
         readonly SafeNativePeripheralManagerHandle _handle;
+        readonly INativePeripheralManagerCallbacks _callbacks;
 
         internal NativePeripheralManagerProxy(SafeNativePeripheralManagerHandle handle, INativePeripheralManagerDelegate peripheralManagerDelegate)
         {
             _handle = handle;
-            if (peripheralManagerDelegate != null)
+            _callbacks = ServiceLocator.Instance.Resolve<INativePeripheralManagerCallbacks>();
+            if (_callbacks != null)
             {
-                s_peripheralManagerDelegateMap[handle.DangerousGetHandle()] = peripheralManagerDelegate;
+                _callbacks.Register(handle, peripheralManagerDelegate);
             }
-
-            RegisterHandlers();
         }
 
         internal void AddService(SafeNativeMutableServiceHandle service)
@@ -100,92 +104,9 @@ namespace CoreBluetooth
             NativeMethods.cb4u_peripheral_manager_respond_to_request(_handle, request.Handle, (int)result);
         }
 
-        void RegisterHandlers()
-        {
-            NativeMethods.cb4u_peripheral_manager_register_handlers(
-                _handle,
-                DidUpdateState,
-                DidAddService,
-                DidStartAdvertising,
-                DidSubscribeToCharacteristic,
-                DidUnsubscribeFromCharacteristic,
-                IsReadyToUpdateSubscribers,
-                DidReceiveReadRequest,
-                DidReceiveWriteRequests
-            );
-        }
-
         public void Dispose()
         {
-            s_peripheralManagerDelegateMap.Remove(_handle.DangerousGetHandle());
-        }
-
-        static INativePeripheralManagerDelegate GetDelegate(IntPtr peripheralPtr)
-        {
-            return s_peripheralManagerDelegateMap.GetValueOrDefault(peripheralPtr);
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidUpdateStateHandler))]
-        public static void DidUpdateState(IntPtr peripheralPtr, CBManagerState state)
-        {
-            GetDelegate(peripheralPtr)?.DidUpdateState(state);
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidAddServiceHandler))]
-        public static void DidAddService(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, int errorCode)
-        {
-            GetDelegate(peripheralPtr)?.DidAddService(
-                Marshal.PtrToStringUTF8(serviceUUIDPtr),
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidStartAdvertisingHandler))]
-        public static void DidStartAdvertising(IntPtr peripheralPtr, int errorCode)
-        {
-            GetDelegate(peripheralPtr)?.DidStartAdvertising(CBError.CreateOrNullFromCode(errorCode));
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidSubscribeToCharacteristicHandler))]
-        public static void DidSubscribeToCharacteristic(IntPtr peripheralPtr, IntPtr centralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr)
-        {
-            GetDelegate(peripheralPtr)?.DidSubscribeToCharacteristic(
-                new SafeNativeCentralHandle(centralPtr),
-                Marshal.PtrToStringUTF8(serviceUUIDPtr),
-                Marshal.PtrToStringUTF8(characteristicUUIDPtr)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidUnsubscribeFromCharacteristicHandler))]
-        public static void DidUnsubscribeFromCharacteristic(IntPtr peripheralPtr, IntPtr centralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr)
-        {
-            GetDelegate(peripheralPtr)?.DidUnsubscribeFromCharacteristic(
-                new SafeNativeCentralHandle(centralPtr),
-                Marshal.PtrToStringUTF8(serviceUUIDPtr),
-                Marshal.PtrToStringUTF8(characteristicUUIDPtr)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerIsReadyToUpdateSubscribersHandler))]
-        public static void IsReadyToUpdateSubscribers(IntPtr peripheralPtr)
-        {
-            GetDelegate(peripheralPtr)?.IsReadyToUpdateSubscribers();
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidReceiveReadRequestHandler))]
-        public static void DidReceiveReadRequest(IntPtr peripheralPtr, IntPtr requestPtr)
-        {
-            GetDelegate(peripheralPtr)?.DidReceiveReadRequest(
-                new SafeNativeATTRequestHandle(requestPtr)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralManagerDidReceiveWriteRequestsHandler))]
-        public static void DidReceiveWriteRequests(IntPtr peripheralPtr, IntPtr requestsPtr)
-        {
-            GetDelegate(peripheralPtr)?.DidReceiveWriteRequests(
-                new SafeNativeATTRequestsHandle(requestsPtr)
-            );
+            _callbacks?.Unregister(_handle);
         }
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativePeripheralProxy.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativePeripheralProxy.cs
@@ -5,20 +5,25 @@ using System.Text;
 
 namespace CoreBluetooth
 {
+    internal interface INativePeripheralCallbacks
+    {
+        void Register(SafeNativePeripheralHandle handle, INativePeripheralDelegate peripheralDelegate);
+        void Unregister(SafeNativePeripheralHandle handle);
+    }
+
     internal class NativePeripheralProxy : IDisposable
     {
-        readonly static Dictionary<IntPtr, INativePeripheralDelegate> s_nativePeripheralDelegateMap = new Dictionary<IntPtr, INativePeripheralDelegate>();
-
         readonly SafeNativePeripheralHandle _handle;
+        readonly INativePeripheralCallbacks _callbacks;
 
         public NativePeripheralProxy(SafeNativePeripheralHandle handle, INativePeripheralDelegate peripheralDelegate)
         {
             _handle = handle;
+            _callbacks = ServiceLocator.Instance.Resolve<INativePeripheralCallbacks>();
             if (peripheralDelegate != null)
             {
-                s_nativePeripheralDelegateMap[handle.DangerousGetHandle()] = peripheralDelegate;
+                _callbacks.Register(handle, peripheralDelegate);
             }
-            RegisterHandlers();
         }
 
         public string Identifier
@@ -154,116 +159,9 @@ namespace CoreBluetooth
             NativeMethods.cb4u_peripheral_read_rssi(_handle);
         }
 
-        void RegisterHandlers()
-        {
-            NativeMethods.cb4u_peripheral_register_handlers(
-                _handle,
-                DidDiscoverServices,
-                DidDiscoverCharacteristics,
-                DidUpdateValueForCharacteristic,
-                DidWriteValueForCharacteristic,
-                IsReadyToSendWriteWithoutResponse,
-                DidUpdateNotificationStateForCharacteristic,
-                DidReadRSSI,
-                DidUpdateName,
-                DidModifyServices
-            );
-        }
-
         public void Dispose()
         {
-            s_nativePeripheralDelegateMap.Remove(_handle.DangerousGetHandle());
-        }
-
-        static INativePeripheralDelegate GetDelegate(IntPtr peripheralPtr)
-        {
-            return s_nativePeripheralDelegateMap.GetValueOrDefault(peripheralPtr);
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidDiscoverServicesHandler))]
-        public static void DidDiscoverServices(IntPtr peripheralPtr, IntPtr commaSeparatedServiceUUIDsPtr, int errorCode)
-        {
-            string commaSeparatedServiceUUIDs = Marshal.PtrToStringUTF8(commaSeparatedServiceUUIDsPtr);
-            GetDelegate(peripheralPtr)?.DidDiscoverServices(
-                commaSeparatedServiceUUIDs.Split(','),
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidDiscoverCharacteristicsHandler))]
-        public static void DidDiscoverCharacteristics(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr commaSeparatedCharacteristicUUIDsPtr, int errorCode)
-        {
-            string commaSeparatedCharacteristicUUIDs = Marshal.PtrToStringUTF8(commaSeparatedCharacteristicUUIDsPtr);
-            GetDelegate(peripheralPtr)?.DidDiscoverCharacteristics(
-                Marshal.PtrToStringUTF8(serviceUUIDPtr),
-                commaSeparatedCharacteristicUUIDs.Split(','),
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateValueForCharacteristicHandler))]
-        public static void DidUpdateValueForCharacteristic(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr, IntPtr dataPtr, int dataLength, int errorCode)
-        {
-            var dataBytes = new byte[dataLength];
-            Marshal.Copy(dataPtr, dataBytes, 0, dataLength);
-
-            GetDelegate(peripheralPtr)?.DidUpdateValueForCharacteristic(
-                Marshal.PtrToStringUTF8(serviceUUIDPtr),
-                Marshal.PtrToStringUTF8(characteristicUUIDPtr),
-                dataBytes,
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidWriteValueForCharacteristicHandler))]
-        public static void DidWriteValueForCharacteristic(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr, int errorCode)
-        {
-            GetDelegate(peripheralPtr)?.DidWriteValueForCharacteristic(
-                Marshal.PtrToStringUTF8(serviceUUIDPtr),
-                Marshal.PtrToStringUTF8(characteristicUUIDPtr),
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralIsReadyToSendWriteWithoutResponseHandler))]
-        public static void IsReadyToSendWriteWithoutResponse(IntPtr peripheralPtr)
-        {
-            GetDelegate(peripheralPtr)?.IsReadyToSendWriteWithoutResponse();
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateNotificationStateForCharacteristicHandler))]
-        public static void DidUpdateNotificationStateForCharacteristic(IntPtr peripheralPtr, IntPtr serviceUUIDPtr, IntPtr characteristicUUIDPtr, int notificationState, int errorCode)
-        {
-            GetDelegate(peripheralPtr)?.DidUpdateNotificationStateForCharacteristic(
-                Marshal.PtrToStringUTF8(serviceUUIDPtr),
-                Marshal.PtrToStringUTF8(characteristicUUIDPtr),
-                notificationState == 1,
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidReadRSSIHandler))]
-        public static void DidReadRSSI(IntPtr peripheralPtr, int rssi, int errorCode)
-        {
-            GetDelegate(peripheralPtr)?.DidReadRSSI(
-                rssi,
-                CBError.CreateOrNullFromCode(errorCode)
-            );
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidUpdateNameHandler))]
-        public static void DidUpdateName(IntPtr peripheralPtr)
-        {
-            GetDelegate(peripheralPtr)?.DidUpdateName();
-        }
-
-        [AOT.MonoPInvokeCallback(typeof(NativeMethods.CB4UPeripheralDidModifyServicesHandler))]
-        public static void DidModifyServices(IntPtr peripheralPtr, IntPtr commaSeparatedServiceUUIDsPtr)
-        {
-            string commaSeparatedServiceUUIDs = Marshal.PtrToStringUTF8(commaSeparatedServiceUUIDsPtr);
-            GetDelegate(peripheralPtr)?.DidModifyServices(
-                commaSeparatedServiceUUIDs.Split(',')
-            );
+            _callbacks.Unregister(_handle);
         }
     }
 }

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/ServiceLocator.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/ServiceLocator.cs
@@ -1,0 +1,33 @@
+
+using System;
+using System.Collections.Generic;
+
+namespace CoreBluetooth
+{
+    internal class ServiceLocator
+    {
+        public static ServiceLocator Instance { get; private set; } = new ServiceLocator();
+        readonly Dictionary<Type, object> container = new Dictionary<Type, object>();
+
+        public void Register<T>(T obj) where T : class
+        {
+            container[typeof(T)] = obj;
+        }
+
+        public bool Unregister<T>() where T : class
+        {
+            return container.Remove(typeof(T));
+        }
+
+        public T Resolve<T>() where T : class
+        {
+            Type targetType = typeof(T);
+            if (container.TryGetValue(targetType, out object obj))
+            {
+                return obj as T;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/ServiceLocator.cs.meta
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/ServiceLocator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bf5f61d29ee5492b88ed01b09a105b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Background

DocFXでドキュメントを生成する際に対象のスクリプトがUnityEngineへの参照を含んでいる場合には
Unityがプリコンパイルしたdllを取得できないとエラーになる。

従ってGitHub Action上でUnityEngineに依存せずにドキュメントを生成するためにはUnityEngineの参照を消したい。

そして

`AOT.MonoPInvokeCallback`はUnityEngineに依存している。(using UnityEngineがなくても)

## Description

- AOT.MonoPInvokeCallbackアトリビュートを持つメソッドをNativeXXCallbacksに移動
- インタフェースを切って直接依存しないようにする
- ServiceLocatorで依存性注入
- 使っていない`using UnityEngine`を削除

これによってNativeXXCallbacksと依存性注入する役割のInitializerを除けばUnityEngineに依存しなくなる。

## クラス名について

NativeXXHandlersやNativeXXEventHandlersも候補だった。
が、イベントハンドラよりはCallbacksのほうがイメージに近かったためこちらを選択。
ただし、メソッド名が「RegisterHandlers」なためそこの不一致があまり気持ちよくない。
優先度は低いため保留する。

## Test
自動テストが動くことを確認したのみ