### PR TITLE
fix RespondToRequest arg to firstRequest

### DIFF
--- a/Assets/CoreBluetooth/Samples/01_LightControl/SampleLightControl_Peripheral.cs
+++ b/Assets/CoreBluetooth/Samples/01_LightControl/SampleLightControl_Peripheral.cs
@@ -85,13 +85,13 @@ namespace CoreBluetoothSample
             {
                 if (request.Characteristic.UUID != SampleLightControl_Data.LightControlCharacteristicUUID)
                 {
-                    peripheral.RespondToRequest(request, CBATTError.RequestNotSupported);
+                    peripheral.RespondToRequest(firstRequest, CBATTError.RequestNotSupported);
                     return;
                 }
 
                 if (request.Value.Length != 7)
                 {
-                    peripheral.RespondToRequest(request, CBATTError.InvalidAttributeValueLength);
+                    peripheral.RespondToRequest(firstRequest, CBATTError.InvalidAttributeValueLength);
                     return;
                 }
             }


### PR DESCRIPTION
> When you respond to a write request, note that the first parameter of the [respond(to:withResult:)](https://developer.apple.com/documentation/corebluetooth/cbperipheralmanager/1393293-respond) method expects a single [CBATTRequest](https://developer.apple.com/documentation/corebluetooth/cbattrequest) object,

https://developer.apple.com/documentation/corebluetooth/cbperipheralmanagerdelegate/1393315-peripheralmanager

実装ミス