### PR TITLE
remove redunadnt Marshal attribute

### DIFF
--- a/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMethods.cs
+++ b/Packages/com.teach310.core-bluetooth-for-unity/Runtime/NativeMethods.cs
@@ -246,7 +246,7 @@ namespace CoreBluetooth
         internal static extern SafeNativeMutableCharacteristicHandle cb4u_mutable_characteristic_new(
             [MarshalAs(UnmanagedType.LPStr), In] string uuid,
             int properties,
-            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 3)] byte[] dataBytes,
+            byte[] dataBytes,
             int dataLength,
             int permissions
         );
@@ -258,7 +258,7 @@ namespace CoreBluetooth
         internal static extern int cb4u_mutable_characteristic_value(SafeNativeMutableCharacteristicHandle handle, byte[] dataBytes, int dataLength);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void cb4u_mutable_characteristic_set_value(SafeNativeMutableCharacteristicHandle handle, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeParamIndex = 2), In] byte[] dataBytes, int dataLength);
+        internal static extern void cb4u_mutable_characteristic_set_value(SafeNativeMutableCharacteristicHandle handle, byte[] dataBytes, int dataLength);
 
         [DllImport(DLL_NAME, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int cb4u_mutable_characteristic_properties(SafeNativeMutableCharacteristicHandle handle);


### PR DESCRIPTION
byte[] は Blittable なため MarshalAs アトリビュートは不要
そしてIn, Out アトリビュートもマーシャリング用なため不要

https://learn.microsoft.com/ja-jp/dotnet/api/system.runtime.interopservices.outattribute?view=net-8.0